### PR TITLE
Update wp.php

### DIFF
--- a/config/tasks/wp.php
+++ b/config/tasks/wp.php
@@ -394,8 +394,6 @@ function wp_core_install(
         );
     }
 
-    run('{{bin/wp}} site empty --yes');
-
     return $result;
 }
 


### PR DESCRIPTION
Prevents accidental emptying of existing posts in a database when setup-wp is executed